### PR TITLE
Replace empty cells with zero

### DIFF
--- a/fileio/@gifti/save.m
+++ b/fileio/@gifti/save.m
@@ -188,6 +188,9 @@ for i=1:length(this.data)
         fprintf(fid,'%s<MD>\n',o(3));
         fprintf(fid,'%s<Name><![CDATA[%s]]></Name>\n',o(4),...
             this.data{i}.metadata(j).name);
+        if isempty(this.data{i}.metadata(j).value)
+            this.data{i}.metadata(j).value = 0;
+        end
         fprintf(fid,'%s<Value><![CDATA[%s]]></Value>\n',o(4),...
             this.data{i}.metadata(j).value);
         fprintf(fid,'%s</MD>\n',o(3));


### PR DESCRIPTION
This function currently fails if `fprintf` receives an empty cell. This is an edit I've made in my copy and it seems to work fine. If you would like an example file for when palm fails, I can upload those so that you can see the error. 

Of note, this does not appear to be a problem for palm116 in octave as the same command runs for palm116 and octave that fails for palm119 and matlab 2020