### PR TITLE
Better binary selection

### DIFF
--- a/palm
+++ b/palm
@@ -35,7 +35,7 @@ WHICH_TO_RUN=1
 # If Octave isn't in the path, or to use a specific version, add here the
 # path or command that invokes the Octave executable binary.
 # This only has effect if WHICH_TO_RUN above os set as 1.
-if [[ ${OCTAVEBIN} == "" ]]
+if [[ ${OCTAVEBIN} == "" ]] ; then
       OCTAVEBIN=/usr/bin/octave
 fi
 #OCTAVEBIN="/usr/bin/flatpak run org.octave.Octave"
@@ -43,7 +43,7 @@ fi
 # If Matlab isn't in the path, or to use a specific version, add here the
 # path or command that invokes the Matlab executable binary.
 # This only has effect if WHICH_TO_RUN above os set as 2.
-if [[ ${MATLABBIN} == "" ]]
+if [[ ${MATLABBIN} == "" ]] ; then
       MATLABBIN=/opt/r16b/bin/matlab
 fi
 

--- a/palm
+++ b/palm
@@ -35,13 +35,17 @@ WHICH_TO_RUN=1
 # If Octave isn't in the path, or to use a specific version, add here the
 # path or command that invokes the Octave executable binary.
 # This only has effect if WHICH_TO_RUN above os set as 1.
-OCTAVEBIN=/usr/bin/octave
+if [[ ${OCTAVEBIN} == "" ]]
+      OCTAVEBIN=/usr/bin/octave
+fi
 #OCTAVEBIN="/usr/bin/flatpak run org.octave.Octave"
 
 # If Matlab isn't in the path, or to use a specific version, add here the
 # path or command that invokes the Matlab executable binary.
 # This only has effect if WHICH_TO_RUN above os set as 2.
-MATLABBIN=/opt/r16b/bin/matlab
+if [[ ${MATLABBIN} == "" ]]
+      MATLABBIN=/opt/r16b/bin/matlab
+fi
 
 # If you are intending to run PALM in a cluster, for some environments
 # it may be necessary to change the variable below to 1.


### PR DESCRIPTION
On MacOS scripting with palm creates the annoying experience of Octave opening the Octave_GUI program in the forground.  This very modest change allows the user to set the Octave excutable through the environmental variable OCTAVEBIN.