### PR TITLE
Extension extraction fix

### DIFF
--- a/palm_miscread.m
+++ b/palm_miscread.m
@@ -81,7 +81,7 @@ X.filename = filename;
 
 % Take the file extension and try to load accordingly
 [~,fnam,fext] = fileparts(X.filename);
-fext = tokenize(strcat(fnam,fext));
+fext = extractAfter(fext,1);
 
 % Some formats use external i/o functions that use random numbers. Save
 % current state of the random number generator, then restore at the end.
@@ -91,7 +91,7 @@ else
     state = rng;
 end
 
-switch lower(fext{end})
+switch fext
 
     case 'txt'
 


### PR DESCRIPTION
In the original version 'tokenize(strcat(fnam,fext))' returns the extension with the dot included (so for 'T1.mgz' -> '.mgz')., while the cases under switch only include the extension.

The fix just extracts anything after the first character. Tokenization is lost, but the other tokens from the file name were not used anywhere else in the script... however, I am not sure if there was another purpose for using tokenize that I might be missing.