### PR TITLE
Fix error writing NIFTIs with Image Processing Toolbox

### DIFF
--- a/palm_miscwrite.m
+++ b/palm_miscwrite.m
@@ -106,8 +106,8 @@ switch lower(X.readwith)
         siz = size(X.data);
         tmp(1:numel(siz)) = siz;
         X.extra.hdr.ImageSize = tmp;
-        X.extra.hdr.DataType = class(X.data);
-        switch X.extra.hdr.DataType
+        X.extra.hdr.Datatype = class(X.data);
+        switch X.extra.hdr.Datatype
             case {'logical','uint8','int8'}
                 X.extra.hdr.BitsPerPixel = 8;
             case {'char','uint16','int16'}


### PR DESCRIPTION
I encountered this error when PALM attempted to save out a NIFTI file:

```
Error using niftiwrite>parseInputs
The value of 'Info' is invalid. Volume class does not match header class specified.

Error in niftiwrite (line 89)
[V, path, filename, params] = parseInputs(V, filename, varargin{:});

Error in palm_miscwrite (line 122)
        niftiwrite(X.data,X.filename,X.extra.hdr);

Error in palm_quicksave (line 163)
    palm_miscwrite(S,true);

Error in palm_core (line 1549)
                                    palm_quicksave(G{y}{m}{c},0,opts,plm,y,m,c, ...

Error in palm (line 81)
palm_core(varargin{:});
```

I *think* the issue is a 1 letter typo in `palm_miscwrite`. It's currently set to "DataType", but `niftiwrite` expects it to be "Datatype" which causes it to fallback to a default value which then doesn't match the actual data type of the volume. Changing it to "Datatype" seems to fix the problem for me?